### PR TITLE
Modified code to not use any blind delays. Also adjusted sensitivities

### DIFF
--- a/src/gpio.c
+++ b/src/gpio.c
@@ -57,11 +57,30 @@ void MX_GPIO_Init(void)
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+  
+    /*Configure GPIO pin : PA5 */
+  GPIO_InitStruct.Pin = GPIO_PIN_5;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
   /*Configure GPIO pin : PA3 */
   GPIO_InitStruct.Pin = GPIO_PIN_3;
   GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
   GPIO_InitStruct.Pull = GPIO_PULLDOWN;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  /*Configure GPIO pin : PA0 */
+  GPIO_InitStruct.Pin = GPIO_PIN_0;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+
+  /*Configure GPIO pin : PA3 */
+  GPIO_InitStruct.Pin = GPIO_PIN_1;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
   HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
 }

--- a/src/usbd_hid.c
+++ b/src/usbd_hid.c
@@ -610,6 +610,10 @@ uint8_t USBD_HID_SendReport(USBD_HandleTypeDef  *pdev,
                        report,
                        len);
     }
+    else
+    {
+      return USBD_BUSY;
+    }
   }
   return USBD_OK;
 }


### PR DESCRIPTION
This PR has changes that instead of waiting a blind duration, polls for:
When a USB transfer is successful to move on to the next
When new sensor data is available.

It also has sensitivities changed for each DoF. I'm not sure how 3D print dependent this is.

There was also a bug in the original code where the MUX register settings for the 1612 were incorrectly written to the ERROR_CONFIG register.